### PR TITLE
Milad

### DIFF
--- a/hello/Tests/Unit_tests/test_email.py
+++ b/hello/Tests/Unit_tests/test_email.py
@@ -1,6 +1,5 @@
 from django.core import mail
 from django.test import TestCase
-from hello.models import *
 
 class EmailTest(TestCase):
     def test_send_email(self):
@@ -17,40 +16,3 @@ class EmailTest(TestCase):
 
         # Verify that the subject of the first message is correct.
         self.assertEqual(mail.outbox[0].subject, 'Subject')
-
-    def test_check_log_data(self):
-        email = "hello@gmail.com"
-        f_name = "Joe"
-        l_name = "Smith"
-        password = "1jhd91hd91"
-        user = User.objects.create(username=email, email=email, first_name=f_name, last_name=l_name, password=password)
-        tank = Tank.objects.create(user=user, name="Office Tank", type="Fr", volume=50)
-        user.save()
-        tank.save()
-
-        user.profile.email_notifications = True
-        user.save()
-
-        # Within param range: no email expected
-        logdata = LogData.objects.create(tank=tank, type=1, value=7.3, time_stamp=datetime.datetime.now())
-        logdata.save()
-        self.assertEqual(len(mail.outbox), 0)
-
-        # Out of param range: email expected
-        logdata = LogData.objects.create(tank=tank, type=1, value=-0.003, time_stamp=datetime.datetime.now())
-        logdata.save()
-
-        # Test that one email has been sent.
-        self.assertEqual(len(mail.outbox), 1)
-
-        # Verify that the subject of the first email is correct.
-        self.assertEqual(mail.outbox[0].subject, 'AquaWatch: tank, Office Tank, has a parameter out of expected range')
-
-        print(mail.outbox[0].message())
-
-        # Out of param range BUT already sent a notification today so no email expected
-        logdata = LogData.objects.create(tank=tank, type=2, value=-3.5, time_stamp=datetime.datetime.now())
-        logdata.save()
-
-        self.assertEqual(len(mail.outbox), 1)
-

--- a/hello/Tests/Unit_tests/test_email.py
+++ b/hello/Tests/Unit_tests/test_email.py
@@ -1,0 +1,18 @@
+from django.core import mail
+from django.test import TestCase
+
+class EmailTest(TestCase):
+    def test_send_email(self):
+        # Send message.
+        result = mail.send_mail(
+            'Subject', 'message.',
+            'from@gmail.com', ['to@gmail.com'],
+            fail_silently=False,
+        )
+        print(result)
+
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        # Verify that the subject of the first message is correct.
+        self.assertEqual(mail.outbox[0].subject, 'Subject')

--- a/hello/Tests/Unit_tests/test_email.py
+++ b/hello/Tests/Unit_tests/test_email.py
@@ -1,5 +1,6 @@
 from django.core import mail
 from django.test import TestCase
+from hello.models import *
 
 class EmailTest(TestCase):
     def test_send_email(self):
@@ -16,3 +17,40 @@ class EmailTest(TestCase):
 
         # Verify that the subject of the first message is correct.
         self.assertEqual(mail.outbox[0].subject, 'Subject')
+
+    def test_check_log_data(self):
+        email = "hello@gmail.com"
+        f_name = "Joe"
+        l_name = "Smith"
+        password = "1jhd91hd91"
+        user = User.objects.create(username=email, email=email, first_name=f_name, last_name=l_name, password=password)
+        tank = Tank.objects.create(user=user, name="Office Tank", type="Fr", volume=50)
+        user.save()
+        tank.save()
+
+        user.profile.email_notifications = True
+        user.save()
+
+        # Within param range: no email expected
+        logdata = LogData.objects.create(tank=tank, type=1, value=7.3, time_stamp=datetime.datetime.now())
+        logdata.save()
+        self.assertEqual(len(mail.outbox), 0)
+
+        # Out of param range: email expected
+        logdata = LogData.objects.create(tank=tank, type=1, value=-0.003, time_stamp=datetime.datetime.now())
+        logdata.save()
+
+        # Test that one email has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        # Verify that the subject of the first email is correct.
+        self.assertEqual(mail.outbox[0].subject, 'AquaWatch: tank, Office Tank, has a parameter out of expected range')
+
+        print(mail.outbox[0].message())
+
+        # Out of param range BUT already sent a notification today so no email expected
+        logdata = LogData.objects.create(tank=tank, type=2, value=-3.5, time_stamp=datetime.datetime.now())
+        logdata.save()
+
+        self.assertEqual(len(mail.outbox), 1)
+

--- a/hello/Tests/Unit_tests/test_text.py
+++ b/hello/Tests/Unit_tests/test_text.py
@@ -1,0 +1,53 @@
+# from sms import send_sms, message
+import sms.utils
+from sms import *
+from django.test import TestCase
+from hello.models import *
+
+class TextTest(TestCase):
+    def test_send_text(self):
+        # Send message.
+        result = send_sms(
+             'message text goes here',
+            '+14145550000', ['+12154158983'],
+            fail_silently=False,
+        )
+        print(result)
+
+        # Test that one message has been sent.
+        self.assertEqual(result, 1)
+
+
+
+    def test_check_log_data(self):
+        email = "hello@gmail.com"
+        f_name = "Joe"
+        l_name = "Smith"
+        password = "1jhd91hd91"
+        user = User.objects.create(username=email, email=email, first_name=f_name, last_name=l_name, password=password)
+        tank = Tank.objects.create(user=user, name="Office Tank", type="Fr", volume=50)
+        user.save()
+        tank.save()
+
+        user.profile.phone_notifications = True
+        user.profile.email_notifications = False
+        user.profile.phone_num = "+14145550000"
+        user.save()
+
+        # Within param range: no text expected
+        logdata = LogData.objects.create(tank=tank, type=1, value=7.3, time_stamp=datetime.datetime.now())
+        logdata.save()
+
+
+        # Out of param range: text expected
+        logdata = LogData.objects.create(tank=tank, type=1, value=-0.003, time_stamp=datetime.datetime.now())
+        logdata.save()
+
+
+
+        # Out of param range BUT already sent a notification today so no text expected
+        logdata = LogData.objects.create(tank=tank, type=2, value=-3.5, time_stamp=datetime.datetime.now())
+        logdata.save()
+
+
+

--- a/hello/Tests/test_models.py
+++ b/hello/Tests/test_models.py
@@ -115,7 +115,7 @@ class ParametersModelTest(TestCase):
         param.save()
         self.assertEqual(param.temp_min, 70)
 
-    def test_parameter_dict_of_range(self):
+    def test_parameter_dict_of_enabled(self):
         param_dict = {
             "temp": True,
             "ph": True,

--- a/hello/Tests/test_models.py
+++ b/hello/Tests/test_models.py
@@ -115,6 +115,22 @@ class ParametersModelTest(TestCase):
         param.save()
         self.assertEqual(param.temp_min, 70)
 
+    def test_parameter_dict_of_range(self):
+        param_dict = {
+            "temp": True,
+            "ph": True,
+            "salinity": True,
+            "ammonia": True,
+        }
+        param = Parameters.objects.get(id=1)
+        self.assertEqual(param.get_dict_of_enabled(), param_dict)
+
+        param.ammonia_enabled = False
+        param.save()
+        param_dict["ammonia"] = False
+        self.assertEqual(param.get_dict_of_enabled(), param_dict)
+
+
 
 
     def test__str__(self):

--- a/hello/models.py
+++ b/hello/models.py
@@ -6,7 +6,7 @@ from phonenumber_field.modelfields import PhoneNumberField  # library for verify
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.core.mail import send_mail
-from sms import send_sms
+
 
 # send_mail(
 #     'Subject here',
@@ -43,13 +43,14 @@ def save_user_profile(sender, instance, **kwargs):
 
 
 class Tank(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE) 
+    user = models.ForeignKey(User, on_delete=models.CASCADE)  # many to one\
 
+    # required, but optional to user, will use generated name if they don't enter one
     name = models.CharField(max_length=20)
     types = [
         ('Fr', 'Freshwater'),
         ('Sa', 'Saltwater'),
-    ] 
+    ]  # may split or add more types later
 
     type = models.CharField(max_length=2, choices=types)
     volume = models.IntegerField()
@@ -57,19 +58,64 @@ class Tank(models.Model):
     send_notifications = models.BooleanField(default=True)
     last_notification_time = models.DateTimeField(blank=True, null=True)
 
-    parameters = models.OneToOneField('Parameters', on_delete=models.CASCADE, null=True, related_name='tank_for_parameters')
+    # one to one relationship to parameters model
 
     def __str__(self):
         return '%s\'s tank: %s' % (self.user.email, self.name)
 
-class Parameters(models.Model):
-    temp_enabled = models.BooleanField(default=True)
-    ph_enabled = models.BooleanField(default=True)
-    salinity_enabled = models.BooleanField(default=True)
-    ammonia_enabled = models.BooleanField(default=True)
-    
-    tank = models.OneToOneField('Tank', on_delete=models.CASCADE, related_name='parameters_for_tank')
 
+class LogData(models.Model):
+    tank = models.ForeignKey(Tank, on_delete=models.CASCADE)  # many to one
+    types = [
+        ('te', 'temp'),
+        ('ph', 'ph'),
+        ('sa', 'salinity'),
+        ('am', 'ammonia'),
+    ]
+    type = models.IntegerField(choices=types)
+    value = models.DecimalField(max_digits=7, decimal_places=3)  # actual recorded number
+    time_stamp = models.DateTimeField()  # should come from user input or Rpi
+    is_manual = models.BooleanField(default=False)
+
+
+    def __str__(self):
+        return 'Tank %s data: %s, %s, %s' % (self.tank.pk, self.type, self.value, self.time_stamp.isoformat())
+
+# 1 notification per day per tank
+@receiver(post_save, sender=LogData)  # uses signals to check new data when its model is created.
+def check_log_data(sender, instance: LogData, created, **kwargs):
+    if created:
+        data = instance
+        param_range = data.tank.parameters.get_dict_of_range().get(data.types[data.type][1])
+        profile = data.tank.user.profile
+        today = datetime.date.today().isoformat()
+        last_notification = data.tank.last_notification_time
+        if last_notification != None:
+            last_notification = last_notification.date().isoformat()
+        tank_notifications = data.tank.send_notifications and (not data.is_manual) and last_notification != today
+        if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
+            if profile.email_notifications:
+                print("when email should be sent")
+                subject = "AquaWatch: tank, %s, has a parameter out of expected range", data.tank.name
+                message = "Parameter, {data.type}, is out of range. \n Reported value: {data.value}"
+                send_mail(
+                    subject,
+                    message,
+                    'from@example.com',
+                    [data.tank.user.email],
+                    fail_silently=False,
+                )
+            if profile.phone_notifications:
+                print("when text should be sent")
+            if profile.phone_notifications or profile.email_notifications:
+                data.tank.last_notification_time = today
+
+
+
+
+
+class Parameters(models.Model):
+    tank = models.OneToOneField(Tank, on_delete=models.CASCADE)  # one to one
     # unit: fahrenheit
     temp_max = models.DecimalField(max_digits=7, decimal_places=3, default=0.0)
     temp_min = models.DecimalField(max_digits=7, decimal_places=3, default=0.0)
@@ -108,78 +154,21 @@ class Parameters(models.Model):
         return param_dict
 
     # intended to get w/ helper, change, then set w/ helper
-    # def set_dict_of_range(self, param_dict: dict[str, list[float, float]]):
-    #     if list(param_dict.keys()) != list(self.get_dict_of_range().keys()):
-    #         raise ValueError("The dict must match keys and types with get_dict_of_range()")
-    #     else:
-    #         self.temp_min = param_dict.get('temp')[0]
-    #         self.temp_max = param_dict.get('temp')[1]
-    #         self.ph_min = param_dict.get('ph')[0]
-    #         self.ph_max = param_dict.get('ph')[1]
-    #         self.salinity_min = param_dict.get('salinity')[0]
-    #         self.salinity_max = param_dict.get('salinity')[1]
-    #         self.ammonia_min = param_dict.get('ammonia')[0]
-    #         self.ammonia_max = param_dict.get('ammonia')[1]
-
-    # def __str__(self):
-    #     return 'Tank %s Parameters' % (self.tank.pk)
-
-class LogData(models.Model):
-    tank = models.ForeignKey(Tank, on_delete=models.CASCADE)  # many to one
-    types = [
-        ('te', 'temp'),
-        ('ph', 'ph'),
-        ('sa', 'salinity'),
-        ('am', 'ammonia'),
-    ]
-    type = models.IntegerField(choices=types)
-    value = models.DecimalField(max_digits=7, decimal_places=3)  # actual recorded number
-    time_stamp = models.DateTimeField()  # should come from user input or Rpi
-    is_manual = models.BooleanField(default=False)
-
+    def set_dict_of_range(self, param_dict: dict[str, list[float, float]]):
+        if list(param_dict.keys()) != list(self.get_dict_of_range().keys()):
+            raise ValueError("The dict must match keys and types with get_dict_of_range()")
+        else:
+            self.temp_min = param_dict.get('temp')[0]
+            self.temp_max = param_dict.get('temp')[1]
+            self.ph_min = param_dict.get('ph')[0]
+            self.ph_max = param_dict.get('ph')[1]
+            self.salinity_min = param_dict.get('salinity')[0]
+            self.salinity_max = param_dict.get('salinity')[1]
+            self.ammonia_min = param_dict.get('ammonia')[0]
+            self.ammonia_max = param_dict.get('ammonia')[1]
 
     def __str__(self):
-        return 'Tank %s data: %s, %s, %s' % (self.tank.pk, self.type, self.value, self.time_stamp.isoformat())
-
-# 1 notification per day per tank
-@receiver(post_save, sender=LogData)  # uses signals to check new data when its model is created.
-def check_log_data(sender, instance: LogData, created, **kwargs):
-    if created:
-        data = instance
-        param_range = data.tank.parameters.get_dict_of_range().get(data.types[data.type][1])
-        profile = data.tank.user.profile
-        today = datetime.date.today().isoformat()
-        last_notification = data.tank.last_notification_time
-        if last_notification != None:
-            last_notification = last_notification.date().isoformat()
-        tank_notifications = data.tank.send_notifications and (not data.is_manual) and last_notification != today
-        if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
-            if profile.phone_notifications or profile.email_notifications:
-                data.tank.last_notification_time = datetime.datetime.today()
-            if profile.email_notifications:
-                print("when email should be sent")
-                subject = f"AquaWatch: tank, {data.tank.name}, has a parameter out of expected range"
-                message = f"Parameter, {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
-                send_mail(
-                    subject,
-                    message,
-                    'from@example.com',
-                    [data.tank.user.email],
-                    fail_silently=False,
-                )
-            if profile.phone_notifications:
-                print("when text should be sent")
-                message = f"AquaWatch: Tank: {data.tank.name},Parameter: {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
-                send_sms(
-                    message,
-                    '+12065550100',
-                    [data.tank.user.profile.phone_num],
-                    fail_silently=False
-                )
-
-
-
-
+        return 'Tank %s Parameters' % (self.tank.pk)
 
 @receiver(post_save, sender=Tank)  # uses signals to create connected param when a tank is created
 def create_tank_params(sender, instance, created, **kwargs):
@@ -190,9 +179,6 @@ def create_tank_params(sender, instance, created, **kwargs):
         elif new_param.tank.type == "Sa":
             new_param.set_dict_of_range(Parameters.saltwater_dict)
         new_param.save()
-        instance.parameters = new_param  # Set the parameters field for the Tank instance
-        instance.save()  # Save the Tank instance
-
 
 @receiver(post_save, sender=Tank)
 def save_rank_params(sender, instance, **kwargs):

--- a/hello/models.py
+++ b/hello/models.py
@@ -157,15 +157,19 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
             if profile.email_notifications:
                 print("when email should be sent")
                 subject = "AquaWatch: tank, %s, has a parameter out of expected range", data.tank.name
+                message = "Parameter, {data.type}, is out of range. \n Reported value: {data.value}"
                 send_mail(
                     subject,
-                    'Here is the message.',
+                    message,
                     'from@example.com',
                     [data.tank.user.email],
                     fail_silently=False,
                 )
             if profile.phone_notifications:
                 print("when text should be sent")
+            if profile.phone_notifications or profile.email_notifications:
+                data.tank.last_notification_time = today
+
 
 
 @receiver(post_save, sender=Tank)  # uses signals to create connected param when a tank is created

--- a/hello/models.py
+++ b/hello/models.py
@@ -97,15 +97,19 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
             if profile.email_notifications:
                 print("when email should be sent")
                 subject = "AquaWatch: tank, %s, has a parameter out of expected range", data.tank.name
+                message = "Parameter, {data.type}, is out of range. \n Reported value: {data.value}"
                 send_mail(
                     subject,
-                    'Here is the message.',
+                    message,
                     'from@example.com',
                     [data.tank.user.email],
                     fail_silently=False,
                 )
             if profile.phone_notifications:
                 print("when text should be sent")
+            if profile.phone_notifications or profile.email_notifications:
+                data.tank.last_notification_time = today
+
 
 
 

--- a/hello/models.py
+++ b/hello/models.py
@@ -156,8 +156,8 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
         if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
             if profile.email_notifications:
                 print("when email should be sent")
-                subject = "AquaWatch: tank, %s, has a parameter out of expected range", data.tank.name
-                message = "Parameter, {data.type}, is out of range. \n Reported value: {data.value}"
+                subject = f"AquaWatch: tank, {data.tank.name}, has a parameter out of expected range"
+                message = f"Parameter, {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
                 send_mail(
                     subject,
                     message,
@@ -168,7 +168,7 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
             if profile.phone_notifications:
                 print("when text should be sent")
             if profile.phone_notifications or profile.email_notifications:
-                data.tank.last_notification_time = today
+                data.tank.last_notification_time = datetime.datetime.today()
 
 
 

--- a/hello/models.py
+++ b/hello/models.py
@@ -96,8 +96,8 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
         if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
             if profile.email_notifications:
                 print("when email should be sent")
-                subject = "AquaWatch: tank, %s, has a parameter out of expected range", data.tank.name
-                message = "Parameter, {data.type}, is out of range. \n Reported value: {data.value}"
+                subject = f"AquaWatch: tank, {data.tank.name}, has a parameter out of expected range"
+                message = f"Parameter, {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
                 send_mail(
                     subject,
                     message,
@@ -108,7 +108,7 @@ def check_log_data(sender, instance: LogData, created, **kwargs):
             if profile.phone_notifications:
                 print("when text should be sent")
             if profile.phone_notifications or profile.email_notifications:
-                data.tank.last_notification_time = today
+                data.tank.last_notification_time = datetime.datetime.today()
 
 
 

--- a/hello/models.py
+++ b/hello/models.py
@@ -6,7 +6,7 @@ from phonenumber_field.modelfields import PhoneNumberField  # library for verify
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.core.mail import send_mail
-
+from sms import send_sms
 
 # send_mail(
 #     'Subject here',
@@ -43,14 +43,13 @@ def save_user_profile(sender, instance, **kwargs):
 
 
 class Tank(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE)  # many to one\
+    user = models.ForeignKey(User, on_delete=models.CASCADE) 
 
-    # required, but optional to user, will use generated name if they don't enter one
     name = models.CharField(max_length=20)
     types = [
         ('Fr', 'Freshwater'),
         ('Sa', 'Saltwater'),
-    ]  # may split or add more types later
+    ] 
 
     type = models.CharField(max_length=2, choices=types)
     volume = models.IntegerField()
@@ -58,64 +57,19 @@ class Tank(models.Model):
     send_notifications = models.BooleanField(default=True)
     last_notification_time = models.DateTimeField(blank=True, null=True)
 
-    # one to one relationship to parameters model
+    parameters = models.OneToOneField('Parameters', on_delete=models.CASCADE, null=True, related_name='tank_for_parameters')
 
     def __str__(self):
         return '%s\'s tank: %s' % (self.user.email, self.name)
 
-
-class LogData(models.Model):
-    tank = models.ForeignKey(Tank, on_delete=models.CASCADE)  # many to one
-    types = [
-        ('te', 'temp'),
-        ('ph', 'ph'),
-        ('sa', 'salinity'),
-        ('am', 'ammonia'),
-    ]
-    type = models.IntegerField(choices=types)
-    value = models.DecimalField(max_digits=7, decimal_places=3)  # actual recorded number
-    time_stamp = models.DateTimeField()  # should come from user input or Rpi
-    is_manual = models.BooleanField(default=False)
-
-
-    def __str__(self):
-        return 'Tank %s data: %s, %s, %s' % (self.tank.pk, self.type, self.value, self.time_stamp.isoformat())
-
-# 1 notification per day per tank
-@receiver(post_save, sender=LogData)  # uses signals to check new data when its model is created.
-def check_log_data(sender, instance: LogData, created, **kwargs):
-    if created:
-        data = instance
-        param_range = data.tank.parameters.get_dict_of_range().get(data.types[data.type][1])
-        profile = data.tank.user.profile
-        today = datetime.date.today().isoformat()
-        last_notification = data.tank.last_notification_time
-        if last_notification != None:
-            last_notification = last_notification.date().isoformat()
-        tank_notifications = data.tank.send_notifications and (not data.is_manual) and last_notification != today
-        if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
-            if profile.email_notifications:
-                print("when email should be sent")
-                subject = f"AquaWatch: tank, {data.tank.name}, has a parameter out of expected range"
-                message = f"Parameter, {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
-                send_mail(
-                    subject,
-                    message,
-                    'from@example.com',
-                    [data.tank.user.email],
-                    fail_silently=False,
-                )
-            if profile.phone_notifications:
-                print("when text should be sent")
-            if profile.phone_notifications or profile.email_notifications:
-                data.tank.last_notification_time = datetime.datetime.today()
-
-
-
-
-
 class Parameters(models.Model):
-    tank = models.OneToOneField(Tank, on_delete=models.CASCADE)  # one to one
+    temp_enabled = models.BooleanField(default=True)
+    ph_enabled = models.BooleanField(default=True)
+    salinity_enabled = models.BooleanField(default=True)
+    ammonia_enabled = models.BooleanField(default=True)
+    
+    tank = models.OneToOneField('Tank', on_delete=models.CASCADE, related_name='parameters_for_tank')
+
     # unit: fahrenheit
     temp_max = models.DecimalField(max_digits=7, decimal_places=3, default=0.0)
     temp_min = models.DecimalField(max_digits=7, decimal_places=3, default=0.0)
@@ -144,6 +98,15 @@ class Parameters(models.Model):
         "ammonia": [0.0, 0.0],
     }
 
+    def get_dict_of_enabled(self):
+        param_dict = {  # "type": boolean format
+            "temp": self.temp_enabled,
+            "ph": self.ph_enabled,
+            "salinity": self.salinity_enabled,
+            "ammonia": self.ammonia_enabled,
+        }
+        return param_dict
+
     def get_dict_of_range(self):
         param_dict = {  # "type": [type_min, type_max] format
             "temp": [self.temp_min.__float__(), self.temp_max.__float__()],
@@ -153,7 +116,7 @@ class Parameters(models.Model):
         }
         return param_dict
 
-    # intended to get w/ helper, change, then set w/ helper
+    #intended to get w/ helper, change, then set w/ helper
     def set_dict_of_range(self, param_dict: dict[str, list[float, float]]):
         if list(param_dict.keys()) != list(self.get_dict_of_range().keys()):
             raise ValueError("The dict must match keys and types with get_dict_of_range()")
@@ -170,6 +133,64 @@ class Parameters(models.Model):
     def __str__(self):
         return 'Tank %s Parameters' % (self.tank.pk)
 
+class LogData(models.Model):
+    tank = models.ForeignKey(Tank, on_delete=models.CASCADE)  # many to one
+    types = [
+        ('te', 'temp'),
+        ('ph', 'ph'),
+        ('sa', 'salinity'),
+        ('am', 'ammonia'),
+    ]
+    type = models.IntegerField(choices=types)
+    value = models.DecimalField(max_digits=7, decimal_places=3)  # actual recorded number
+    time_stamp = models.DateTimeField()  # should come from user input or Rpi
+    is_manual = models.BooleanField(default=False)
+
+
+    def __str__(self):
+        return 'Tank %s data: %s, %s, %s' % (self.tank.pk, self.type, self.value, self.time_stamp.isoformat())
+
+# 1 notification per day per tank
+@receiver(post_save, sender=LogData)  # uses signals to check new data when its model is created.
+def check_log_data(sender, instance: LogData, created, **kwargs):
+    if created:
+        data = instance
+        param_range = data.tank.parameters.get_dict_of_range().get(data.types[data.type][1])
+        is_enabled = data.tank.parameters.get_dict_of_enabled().get(data.types[data.type][1])
+        profile = data.tank.user.profile
+        today = datetime.date.today().isoformat()
+        last_notification = data.tank.last_notification_time
+        if last_notification is not None:
+            last_notification = last_notification.date().isoformat()
+        tank_notifications = data.tank.send_notifications and (not data.is_manual) and last_notification != today and is_enabled
+        if tank_notifications and (data.value < param_range[0] or data.value > param_range[1]): # value is out of bounds
+            if profile.phone_notifications or profile.email_notifications:
+                data.tank.last_notification_time = datetime.datetime.today()
+            if profile.email_notifications:
+                print("when email should be sent")
+                subject = f"AquaWatch: tank, {data.tank.name}, has a parameter out of expected range"
+                message = f"Parameter, {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
+                send_mail(
+                    subject,
+                    message,
+                    'from@example.com',
+                    [data.tank.user.email],
+                    fail_silently=False,
+                )
+            if profile.phone_notifications:
+                print("when text should be sent")
+                message = f"AquaWatch: Tank: {data.tank.name},Parameter: {data.types[data.type][1]}, is out of range. \nReported value: {data.value}"
+                send_sms(
+                    message,
+                    '+12065550100',
+                    [data.tank.user.profile.phone_num],
+                    fail_silently=False
+                )
+
+
+
+
+
 @receiver(post_save, sender=Tank)  # uses signals to create connected param when a tank is created
 def create_tank_params(sender, instance, created, **kwargs):
     if created:
@@ -179,6 +200,9 @@ def create_tank_params(sender, instance, created, **kwargs):
         elif new_param.tank.type == "Sa":
             new_param.set_dict_of_range(Parameters.saltwater_dict)
         new_param.save()
+        instance.parameters = new_param  # Set the parameters field for the Tank instance
+        instance.save()  # Save the Tank instance
+
 
 @receiver(post_save, sender=Tank)
 def save_rank_params(sender, instance, **kwargs):

--- a/hello/tasks.py
+++ b/hello/tasks.py
@@ -1,0 +1,22 @@
+import datetime
+import time
+
+from django_q.tasks import async_task, schedule
+from django_q.models import Schedule
+from models import *
+
+#  check if modules that were sending logdatas stopped sending data if so send a connection issue notification
+def check_module_logging():
+    tanks = list(Tank.objects.all())
+    for tank in tanks:
+        data = LogData.objects.filter(is_manual=False, tank=tank)
+        most_recent= data.objects.order_by('time_stamp').first()
+        if most_recent is not None:
+            now = datetime.datetime.now()
+            minutes_since_update = datetime.timedelta(now, most_recent.time_stamp).total_seconds() % 60
+            if 30 < minutes_since_update < 62:  # replace with something more reliable
+                # send notification: can't connect to module; internet, power, or hardware issue
+                pass
+
+#  change to start after n mins so it doesn't send notifications on server start, before everything is going
+schedule('tasks.check_module_logging', schedule_type=Schedule.minutes, minutes=30)

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -132,6 +132,16 @@ STATIC_URL = 'static/'
 ALLOWED_HOSTS = ['*']
 X_FRAME_OPTIONS = '*'
 
+# console backend for testing emails
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# EMAIL_HOST = 'smtp.gmail.com'
+# EMAIL_HOST_USER = 'myemailaddress@gmail.com'
+# EMAIL_HOST_PASSWORD = 'mypassword'
+# EMAIL_USE_TLS = True
+# EMAIL_PORT = 587
+# DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -132,9 +132,6 @@ STATIC_URL = 'static/'
 ALLOWED_HOSTS = ['*']
 X_FRAME_OPTIONS = '*'
 
-# console backend for testing texts
-SMS_BACKEND = 'sms.backends.console.SmsBackend'
-
 # console backend for testing emails
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST = 'smtp.gmail.com'

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -132,6 +132,9 @@ STATIC_URL = 'static/'
 ALLOWED_HOSTS = ['*']
 X_FRAME_OPTIONS = '*'
 
+# console backend for testing texts
+SMS_BACKEND = 'sms.backends.console.SmsBackend'
+
 # console backend for testing emails
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST = 'smtp.gmail.com'

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -132,6 +132,10 @@ STATIC_URL = 'static/'
 ALLOWED_HOSTS = ['*']
 X_FRAME_OPTIONS = '*'
 
+# console backend for testing texts
+SMS_BACKEND = 'sms.backends.console.SmsBackend'
+
+
 # console backend for testing emails
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST = 'smtp.gmail.com'

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'phonenumber_field',
     'hello',
+    'django_q',
 ]
 
 MIDDLEWARE = [
@@ -81,7 +82,17 @@ DATABASES = {
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
-
+# Django-q config
+Q_CLUSTER = {
+    'name': 'DjangORM',
+    'workers': 4,
+    'timeout': 90,
+    'retry': 120,
+    'queue_limit': 50,
+    'bulk': 10,
+    'orm': 'default',
+    'sync': True,  # must be True if running on Windows
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators


### PR DESCRIPTION
text and email notifications for logdata out of param range (all printing to console for now). Tests for email and text. Param enable/disable checking for notifications and related model and model_test additions. Django-Q is for automated/scheduled tasks, intended to check if a module stopped sending data, not complete or tested. 